### PR TITLE
Add webpush tests for message delivery with crypto settings.

### DIFF
--- a/pushtest/client.py
+++ b/pushtest/client.py
@@ -101,6 +101,7 @@ class Client(object):
                 "Encryption": self._crypto_key,
             }
             body = data or ""
+            method = "POST"
         else:
             if data:
                 body = "version=%s&data=%s" % (version or "", data)
@@ -110,11 +111,12 @@ class Client(object):
                 headers = {"Content-Type": "application/x-www-form-urlencoded"}
             else:
                 headers = {}
+            method = "PUT"
 
-        log.debug("PUT body: %s", body)
-        http.request("PUT", url.path, body, headers)
+        log.debug("%s body: %s", method, body)
+        http.request(method, url.path, body, headers)
         resp = http.getresponse()
-        log.debug("PUT Response: %s", resp.read())
+        log.debug("%s Response: %s", method, resp.read())
         eq_(resp.status, status)
 
         # Pull the notification if connected

--- a/pushtest/client.py
+++ b/pushtest/client.py
@@ -37,12 +37,11 @@ class Client(object):
             chans = self.channels.keys()
         else:
             chans = []
+        hello_dict = dict(messageType="hello", uaid=self.uaid or "",
+                          channelIDs=chans)
         if self.use_webpush:
-            msg = json.dumps(dict(messageType="hello", uaid=self.uaid or "",
-                                  use_webpush=True, channelIDs=chans))
-        else:
-            msg = json.dumps(dict(messageType="hello", uaid=self.uaid or "",
-                                  channelIDs=chans))
+            hello_dict["use_webpush"] = True
+        msg = json.dumps(hello_dict)
         log.debug("Send: %s", msg)
         self.ws.send(msg)
         result = json.loads(self.ws.recv())

--- a/pushtest/client.py
+++ b/pushtest/client.py
@@ -99,9 +99,11 @@ class Client(object):
                 "Content-Type": "application/octet-stream",
                 "Content-Encoding": "aesgcm-128",
                 "Encryption": self._crypto_key,
+                "Encryption-Key": 'keyid="a1"; key="JcqK-OLkJZlJ3sJJWstJCA"'
             }
             body = data or ""
             method = "POST"
+            status = 201
         else:
             if data:
                 body = "version=%s&data=%s" % (version or "", data)

--- a/pushtest/client.py
+++ b/pushtest/client.py
@@ -120,6 +120,8 @@ class Client(object):
         resp = http.getresponse()
         log.debug("%s Response: %s", method, resp.read())
         eq_(resp.status, status)
+        if self.use_webpush:
+            assert(resp.getheader("Location", None) is not None)
 
         # Pull the notification if connected
         if self.ws and self.ws.connected:

--- a/pushtest/test_webpush.py
+++ b/pushtest/test_webpush.py
@@ -156,6 +156,7 @@ def test_no_delivery_to_unregistered(url=None):
 
     client.unregister(chan)
     client.disconnect()
+    time.sleep(1)
     client.connect()
     client.hello()
     result = client.get_notification()

--- a/pushtest/test_webpush.py
+++ b/pushtest/test_webpush.py
@@ -1,0 +1,162 @@
+import os
+import time
+import uuid
+
+from nose.tools import eq_, ok_
+
+from pushtest.client import (
+    Client,
+    quick_register
+)
+
+
+def check_environ():
+    return os.environ.get("PUSH_SERVER")
+
+
+def test_hello_echo(url=None):
+    url = url or check_environ()
+    client = Client(url, use_webpush=True)
+    client.connect()
+    result = client.hello()
+    ok_(result != {})
+    eq_(result["use_webpush"], True)
+
+
+def test_basic_delivery(url=None):
+    data = str(uuid.uuid4())
+    url = url or check_environ()
+    client = quick_register(url, use_webpush=True)
+    result = client.send_notification(data=data)
+    eq_(result["headers"]["encryption"], client._crypto_key)
+    eq_(result["data"], data)
+    eq_(result["messageType"], "notification")
+
+
+def test_delivery_repeat_without_ack(url=None):
+    data = str(uuid.uuid4())
+    url = url or check_environ()
+    client = quick_register(url, use_webpush=True)
+    client.disconnect()
+    ok_(client.channels)
+    client.send_notification(data=data, status=202)
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    ok_(result != {})
+    eq_(result["data"], data)
+
+    client.disconnect()
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    ok_(result != {})
+    eq_(result["data"], data)
+
+
+def test_multiple_delivery_repeat_without_ack(url=None):
+    data = str(uuid.uuid4())
+    data2 = str(uuid.uuid4())
+    url = url or check_environ()
+    client = quick_register(url, use_webpush=True)
+    client.disconnect()
+    ok_(client.channels)
+    client.send_notification(data=data, status=202)
+    client.send_notification(data=data2, status=202)
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+
+    client.disconnect()
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+
+
+def test_multiple_delivery_with_single_ack(url=None):
+    data = str(uuid.uuid4())
+    data2 = str(uuid.uuid4())
+    url = url or check_environ()
+    client = quick_register(url, use_webpush=True)
+    client.disconnect()
+    ok_(client.channels)
+    client.send_notification(data=data, status=202)
+    client.send_notification(data=data2, status=202)
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+    client.ack(result["channelID"], result["version"])
+
+    client.disconnect()
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+    ok_(result["messageType"], "notification")
+    result = client.get_notification()
+    eq_(result, None)
+
+
+def test_multiple_delivery_with_multiple_ack(url=None):
+    data = str(uuid.uuid4())
+    data2 = str(uuid.uuid4())
+    url = url or check_environ()
+    client = quick_register(url, use_webpush=True)
+    client.disconnect()
+    ok_(client.channels)
+    client.send_notification(data=data, status=202)
+    client.send_notification(data=data2, status=202)
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    ok_(result != {})
+    ok_(result["data"] in [data, data2])
+    result2 = client.get_notification()
+    ok_(result2 != {})
+    ok_(result2["data"] in [data, data2])
+    client.ack(result2["channelID"], result2["version"])
+    client.ack(result["channelID"], result["version"])
+
+    client.disconnect()
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    eq_(result, None)
+
+
+def test_no_delivery_to_unregistered(url=None):
+    data = str(uuid.uuid4())
+    url = url or check_environ()
+    client = quick_register(url, use_webpush=True)
+    client.disconnect()
+    ok_(client.channels)
+    chan = client.channels.keys()[0]
+    client.send_notification(data=data, status=202)
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    eq_(result["channelID"], chan)
+    eq_(result["data"], data)
+
+    client.unregister(chan)
+    client.disconnect()
+    client.connect()
+    client.hello()
+    result = client.get_notification()
+    eq_(result, None)


### PR DESCRIPTION
This add's a suite of webpush smoke tests to ensure:
- Individual messages are sent for a channel
- Ack's work properly
- Unregistering from a channel works

@kitcambridge, @jrconlin r?