### PR TITLE
For python 2.7.11

### DIFF
--- a/prod-reqs.txt
+++ b/prod-reqs.txt
@@ -1,4 +1,4 @@
 argparse==1.1
-distribute==0.6.40
+distribute==0.7.3
 websocket-client==0.10.0
 wsgiref==0.1.2


### PR DESCRIPTION
Whit-out this upgrade I cannot run ``make´´ command on ubuntu 14.04.3 - python 2.7.11
